### PR TITLE
Fix #25 and jumping when using target mode

### DIFF
--- a/src/com/johnlindquist/acejump/keycommands/DefaultKeyCommand.kt
+++ b/src/com/johnlindquist/acejump/keycommands/DefaultKeyCommand.kt
@@ -49,12 +49,17 @@ public class DefaultKeyCommand(val searchBox: SearchBox, val aceFinder: AceFinde
                     aceJumper.selectWordAtCaret()
                 }
             }
-            else{
+            else if (couldPossiblyMatch(char!!)){
                 aceFinder.firstChar = char!!
             }
 
         }
 
+    }
+
+    // we don't want to collect chars which would lead us to nowhere
+    private fun couldPossiblyMatch(char: String): Boolean {
+        return textAndOffsetHash.keySet().any { it.startsWith(char) }
     }
 
 


### PR DESCRIPTION
I've found out that jumping didn't work when using target mode. Additionally when using normal mode, when having multiple matches, hitting a key which was not on the list, would lead to a behaviour as described in an issue #25.

I believe the reason was that the characters were collected, even if they could never lead to a successful jump, and pressing more characters would just increase the buffer of collected chars (the target jump didn't work because ';' was also collected). I think this commit would fix it.

PS. the project didn't compile and I had to change some stuff, but that's not included in the pull-request, as today was literally first time I did something with Kotlin, and I'm not sure if that's general problem or my misconfiguration.